### PR TITLE
Update configuration.mdx

### DIFF
--- a/website/docs/getting_started/configuration.mdx
+++ b/website/docs/getting_started/configuration.mdx
@@ -79,11 +79,11 @@ Use command `fvm list` to show you the cache path to the versions.
 
 #### List all versions installed by FVM
 
-You can see all the versions installed by FVM in VS Code by just providing path to `versions` directory:
+You can see all the versions installed by FVM in VS Code by just providing path to `versions` directory. In the following example path for macOS, replace `$USER` with your username:
 
 ```json
 {
-  "dart.flutterSdkPaths": ["/Users/usr/fvm/versions"]
+  "dart.flutterSdkPaths": ["/Users/$USER/fvm/versions"]
 }
 ```
 
@@ -92,8 +92,8 @@ Alternatively, you can specify only selected versions. The following snippet wil
 ```json
 {
   "dart.flutterSdkPaths": [
-    "/Users/usr/fvm/versions/stable",
-    "/Users/usr/fvm/versions/dev"
+    "/Users/$USER/fvm/versions/stable",
+    "/Users/$USER/fvm/versions/dev"
   ]
 }
 ```


### PR DESCRIPTION
The `/Users` path example seems to imply a macOS system. This clarifies that `usr` should be replaced by your actual macOS username, and is not some kind of weird directory installed by fvm.

When installing fvm & reading the docs, I was on a copy-paste frenzy. I just copy-pasted the `/Users/usr/...` path without looking at it much. Of course that didn't work.