### PR TITLE
feat: implement short hand commands for install and list options

### DIFF
--- a/lib/src/commands/install_command.dart
+++ b/lib/src/commands/install_command.dart
@@ -22,6 +22,9 @@ class InstallCommand extends BaseCommand {
   String get invocation => 'fvm install {version}, if no {version}'
       ' is provided will install version configured in project.';
 
+  @override
+  List<String> get aliases => ['i'];
+
   /// Constructor
   InstallCommand() {
     argParser.addFlag(

--- a/lib/src/commands/list_command.dart
+++ b/lib/src/commands/list_command.dart
@@ -17,6 +17,9 @@ class ListCommand extends BaseCommand {
   @override
   final description = 'Lists installed Flutter SDK Versions';
 
+  @override
+  List<String> get aliases => ['ls'];
+
   /// Constructor
   ListCommand();
 


### PR DESCRIPTION
## Details:
- This change provides a new way to call `install` and `list` commands in FVM, now users can use `'i'` as a short-hand command while trying to install a new version and use `'ls'` as short-hand command while trying to list installed versions.

### Usage examples 
`fvm i X.X.X` or `fvm install X.X.X`

![Screenshot 2023-02-17 at 14 47 13](https://user-images.githubusercontent.com/44684314/219741282-17ba0ebe-843e-4783-a425-ea5b72d37fe9.png)
![Screenshot 2023-02-17 at 14 48 43](https://user-images.githubusercontent.com/44684314/219741365-01f54701-34d1-4b84-86fd-3018572b54ac.png)

`fvm ls` or `fvm list`

![Screenshot 2023-02-17 at 14 45 43](https://user-images.githubusercontent.com/44684314/219741148-e46eede4-0305-4fdc-b976-c9bf056c4773.png)

This PR closes #502 