### PR TITLE
fix: display colors on flutter commands

### DIFF
--- a/lib/src/utils/commands.dart
+++ b/lib/src/utils/commands.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:io/io.dart';
 import 'package:process_run/shell.dart';
 
 import '../../constants.dart';
@@ -108,21 +107,15 @@ Future<int> _runCmd(
     await Guards.canExecute(execPath, args);
   }
 
-  final processManager = ProcessManager();
-
   // Switch off line mode
   switchLineMode(false, args);
-  final process = await processManager.spawn(
+  final process = await Process.start(
     execPath,
     args,
     environment: environment,
     workingDirectory: kWorkingDirectory.path,
+    mode: ProcessStartMode.inheritStdio,
   );
-
-  if (!ConsoleController.isCli) {
-    process.stdout.listen(consoleController.stdout.add);
-    process.stderr.listen(consoleController.stderr.add);
-  }
 
   exitCode = await process.exitCode;
 


### PR DESCRIPTION
Previously, colors were disabled because `flutter` thinks we are not on a terminal session. Now we make the child process share the same stdout and stderr as the parent which was in fact spawned in a terminal session, thus showing colors :^).

**Before**

https://user-images.githubusercontent.com/7662016/222934909-b3d46479-2f53-45e8-a808-ef94a2352149.mp4

**After**

https://user-images.githubusercontent.com/7662016/222934912-122c3ddf-d760-4d4d-b549-ac6a865ae2a2.mp4
