### PR TITLE
Add space after period in fvm config help

### DIFF
--- a/lib/src/commands/config_command.dart
+++ b/lib/src/commands/config_command.dart
@@ -20,7 +20,7 @@ class ConfigCommand extends BaseCommand {
       ..addOption(
         'cache-path',
         help: 'Set the path which FVM will cache the version.'
-            'Priority over FVM_HOME.',
+            ' Priority over FVM_HOME.',
         abbr: 'c',
       )
       ..addFlag(


### PR DESCRIPTION
Adds a space after the period in `fvm config --cache-path` usage instructions.

Currently:

```
-c, --cache-path         Set the path which FVM will cache the version.Priority over FVM_HOME.
```

With this fix:
```
-c, --cache-path         Set the path which FVM will cache the version. Priority over FVM_HOME.
```